### PR TITLE
#5 選択肢の入力

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -11,17 +11,8 @@ export default {
   components: {
     Header
   },
-  data: function () {
-    return {
-      message: "Hello Vue!"
-    }
-  }
 }
 </script>
 
 <style scoped>
-p {
-  font-size: 2em;
-  text-align: center;
-}
 </style>

--- a/app/javascript/pages/analysis/alternative_input.vue
+++ b/app/javascript/pages/analysis/alternative_input.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="container">
+    <h3>STEP1 就職先の選択肢を入力してください</h3>
+    {{ checkAlternatives }}
+    <div class="col-8 offset-2">
+      <div
+        v-for="(item, index) in alternatives"
+        :key="index"
+      >
+        <input
+          v-model="alternatives[index]"
+          class="form-control"
+        >
+      </div>
+      <button
+        type="button"
+        class="btn btn-success"
+        @click="addForm"
+      >
+        追加
+      </button>
+      <button
+        type="button"
+        class="btn btn-success"
+        @click="handleAlternative"
+      >
+        決定
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+export default {
+  name: 'Login',
+  data() {
+    return {
+      alternatives: [null, null, null],
+      errors: null
+    }
+  },
+  methods: {
+    handleErrors() {
+      this.errors = null
+    },
+    addForm() {
+      this.alternatives.push(null)
+    },
+    handleAlternative() {
+      this.setAlternatives(this.alternatives)
+    },
+    ...mapActions('analysis', ['setAlternatives'])
+  }
+}
+</script>
+
+<style scoped>
+input {
+  margin-bottom: 10px;
+}
+</style>

--- a/app/javascript/pages/home.vue
+++ b/app/javascript/pages/home.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="col-4 offset-4">
+    <h1>トップページ</h1>
+    <router-link
+      to="/analysis/step1"
+      class="btn btn-success"
+    >
+      スタート
+    </router-link>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Home',
+}
+</script>
+
+<style scoped>
+input {
+  margin-bottom: 10px;
+}
+</style>

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -1,18 +1,21 @@
 import Vue from 'vue'
 import Router from 'vue-router'
+import Home from '../pages/home.vue'
 import Register from '../pages/register.vue'
 import Login from '../pages/login.vue'
 import MyPage from '../pages/mypage.vue'
+import AlternativeInput from '../pages/analysis/alternative_input.vue'
 import store from '../store/index.js'
 
 Vue.use(Router)
 
 const router = new Router({
     mode: "history",
-    // routes: [{path: '/', component: Home}],
-    routes: [{path: '/register', component: Register},
+    routes: [{path: '/', component: Home},
+             {path: '/register', component: Register},
              {path: '/login', component: Login},
-             {path: '/mypage', component: MyPage, meta: { requiredAuth: true }}]
+             {path: '/mypage', component: MyPage, meta: { requiredAuth: true }},
+             {path: '/analysis/step1', component: AlternativeInput}]
 })
 
 router.beforeEach((to, from, next) => {

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -1,11 +1,13 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import users from './modules/users.js'
+import analysis from './modules/analysis.js'
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
   modules: {
-    users: users,
+    users,
+    analysis
   }
 })

--- a/app/javascript/store/modules/analysis.js
+++ b/app/javascript/store/modules/analysis.js
@@ -1,0 +1,25 @@
+import axios from '../../plugins/axios.js'
+const state = {
+  alternatives: null
+}
+const getters = {
+  getAlternatives: state => state.alternatives
+}
+const mutations = {
+  setAlternatives(state, array) {
+    state.alternatives = array
+  }
+}
+const actions = {
+  setAlternatives({commit}, array) {
+    commit('setAlternatives', array)
+  }
+}
+
+export default {
+  state,
+  getters,
+  mutations,
+  actions,
+  namespaced: true
+}


### PR DESCRIPTION
# issue
#5

# 概要
就職先の選択肢の入力機能

# 変更点
トップページ

- トップページのコンポーネントpages/home.vueを作成
- home.vueに分析スタートボタンを設置し、このボタンから就職先入力ページに遷移するよう記述

就職先入力ページ

- 就職先入力ページのコンポーネントpages/analysis/alternative_input.vueを作成
- ページ内のフォームでdataプロパティ内の就職先データを編集し、決定ボタンでVuexに送るよう記述
- デフォルトのフォームの個数を３つとし、フォームを追加する機能を実装

analysisモジュール

- 分析用データのモジュールとしてstore/modules/analysis.jsを作成
- コンポーネントから送られてきた就職先データをstate.alternativesとしてストアするようmutationsとactionsを記述