### PR TITLE
#5 評価基準の選択

### DIFF
--- a/app/javascript/pages/analysis/alternative_input.vue
+++ b/app/javascript/pages/analysis/alternative_input.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="container">
     <h3>STEP1 就職先の選択肢を入力してください</h3>
-    {{ checkAlternatives }}
     <div class="col-8 offset-2">
       <div
         v-for="(item, index) in alternatives"
@@ -48,7 +47,9 @@ export default {
       this.alternatives.push(null)
     },
     handleAlternative() {
-      this.setAlternatives(this.alternatives)
+      const array = this.alternatives.filter(v => v)
+      this.setAlternatives(array)
+      this.$router.push('/analysis/step2')
     },
     ...mapActions('analysis', ['setAlternatives'])
   }

--- a/app/javascript/pages/analysis/criteria_input.vue
+++ b/app/javascript/pages/analysis/criteria_input.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="container">
+    <h3>STEP2 就職先を決める上で考慮する条件を選んでください</h3>
+    <div class="col-8 offset-2">
+      <div
+        v-for="(item, index) in criteria"
+        :key="item"
+      >
+        <input
+          :id="index"
+          v-model="selectedCriteria"
+          type="checkbox"
+          :value="item"
+        ><label :for="index">{{ item }}</label>
+      </div>
+      <div
+        v-for="n in criteriaAdditionNumber"
+        :key="n"
+      >
+        <input
+          v-model="selectedCriteria"
+          type="checkbox"
+          :value="addedCriteria[n-1]"
+        >
+        <input v-model="addedCriteria[n-1]">
+      </div>
+      <button
+        type="button"
+        class="btn btn-success"
+        @click="addCriteria"
+      >
+        追加
+      </button>
+      <button
+        type="button"
+        class="btn btn-success"
+        @click="handleCriteria"
+      >
+        決定
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+import { mapGetters } from 'vuex'
+export default {
+  name: 'Login',
+  data() {
+    return {
+      criteria: [
+        '労働時間',
+        '通勤時間',
+        '雇用の安定',
+        '仕事の裁量権',
+        '社会への貢献度',
+        '周囲のサポートの充実度',
+        'ワークライフバランス',
+        'タスク/評価基準の明確性',
+        '仕事の幅広さ',
+        '福利厚生',
+        '達成感',
+        '収入'
+      ],
+      selectedCriteria: [],
+      addedCriteria: [],
+      criteriaAdditionNumber: 0,
+      errors: null
+    }
+  },
+  computed: {
+    fetchAlternative() {
+      return this.getAlternatives
+    },
+    ...mapGetters('analysis', ['getAlternatives'])
+  },
+  methods: {
+    handleErrors() {
+      this.errors = null
+    },
+    addCriteria() {
+      this.criteriaAdditionNumber += 1
+    },
+    handleCriteria() {
+      const array = this.selectedCriteria.filter(v => v)
+      this.setCriteria(array)
+    },
+    ...mapActions('analysis', ['setCriteria'])
+  }
+}
+</script>
+
+<style scoped>
+input {
+  margin-bottom: 10px;
+}
+</style>

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -5,6 +5,7 @@ import Register from '../pages/register.vue'
 import Login from '../pages/login.vue'
 import MyPage from '../pages/mypage.vue'
 import AlternativeInput from '../pages/analysis/alternative_input.vue'
+import CriteriaInput from '../pages/analysis/criteria_input.vue'
 import store from '../store/index.js'
 
 Vue.use(Router)
@@ -15,7 +16,8 @@ const router = new Router({
              {path: '/register', component: Register},
              {path: '/login', component: Login},
              {path: '/mypage', component: MyPage, meta: { requiredAuth: true }},
-             {path: '/analysis/step1', component: AlternativeInput}]
+             {path: '/analysis/step1', component: AlternativeInput},
+             {path: '/analysis/step2', component: CriteriaInput}]
 })
 
 router.beforeEach((to, from, next) => {

--- a/app/javascript/store/modules/analysis.js
+++ b/app/javascript/store/modules/analysis.js
@@ -1,18 +1,26 @@
 import axios from '../../plugins/axios.js'
 const state = {
-  alternatives: null
+  alternatives: null,
+  criteria: null
 }
 const getters = {
-  getAlternatives: state => state.alternatives
+  getAlternatives: state => state.alternatives,
+  getCriteria: state => state.criteria
 }
 const mutations = {
   setAlternatives(state, array) {
     state.alternatives = array
+  },
+  setCriteria(state, array) {
+    state.criteria = array
   }
 }
 const actions = {
   setAlternatives({commit}, array) {
     commit('setAlternatives', array)
+  },
+  setCriteria({commit}, array) {
+    commit('setCriteria', array)
   }
 }
 


### PR DESCRIPTION
# issue
#5 
# 概要
就職先選びの評価基準の選択機能を実装
# 変更点
就職先入力ページ

- 就職先入力ページの決定ボタンで評価基準選択ページに遷移するよう処理を追加

評価基準選択ページ

- 評価基準選択ページのコンポーネントpages/analysis/criteria_input.vueを作成
- ページ内のチェックボックスで評価基準を複数選択しdataプロパティのselectedCriteria(配列)に追加する処理を記述
- オリジナルの評価基準をつくるためのチェックボックス＋フォームを生成するボタンを設置
- そのフォームに入力しチェックするとselectedCriteriaに追加される処理を記述
- 決定ボタンでselectedCriteriaがVuexに送るよう記述

analysisモジュール

- コンポーネントから送られてきた評価基準データをstate.criteriaとしてストアするようmutationsとactionsを記述