### PR TITLE
#5 基準ごとの選択肢の評価機能

### DIFF
--- a/app/javascript/pages/analysis/AlternativeEvaluation.vue
+++ b/app/javascript/pages/analysis/AlternativeEvaluation.vue
@@ -3,45 +3,29 @@
     <h3>STEP4 条件ごとにどちらの就職先が優れているか比較してください</h3>
     <div class="col-8 offset-2">
       <div
-        v-for="(item, index) in combinationArray"
+        v-for="(item, index) in criteria"
         :key="index"
-        class="row"
       >
-        <div class="col">
-          <span>
-            {{ item[0] }}
-          </span>
+        <div>
+          {{ item }}
         </div>
-        <div class="col">
-          <span
-            v-for="n in 7"
-            :key="n"
-            class="input-inline"
-          >
-          <input
-            v-model="inputValues[index]"
-            type="radio"
-            :value="n"
-            >
-          </span>
-        </div>
-        <div class="col">
-          <span>
-            {{ item[1] }}
-          </span>
-        </div>
+        <EvaluationList
+          :combination-array="combinationArray"
+          :list-name="item"
+          @catch-data="setEvaluationDataCollection(item, index, $event)"
+        />
       </div>
       <router-link
         type="button"
         class="btn btn-secondary"
-        to="/analysis/step2"
+        to="/analysis/step3"
       >
         戻る
       </router-link>
       <button
         type="button"
         class="btn btn-success"
-        @click="handleCriteriaPriority"
+        @click="handleAlternativeEvaluation"
       >
         決定
       </button>
@@ -52,71 +36,47 @@
 <script>
 import { mapActions } from 'vuex'
 import { mapGetters } from 'vuex'
+import EvaluationList from './components/EvaluationList.vue'
 export default {
   name: 'AlternativeEvaluation',
+  components: {
+    EvaluationList
+  },
   data() {
     return {
       combinationArray: [],
-      inputValues: [],
+      evaluationDataCollection: [],
+      criteria: [],
       errors: null
     }
   },
   created() {
-    const cri = this.getCriteria
-    let i, j
-    for(i = 1; i < cri.length; i++){
-      const arr = cri.slice(i-1)
-      for(j = 1; j < arr.length; j++){
-        this.combinationArray.push([arr[0], arr[j]])
-      }
-    }
+    this.combinationArray = this.$calculator.makePairs(this.getAlternatives)
+    this.criteria = this.getCriteria
   },
   computed: {
-    ...mapGetters('analysis', ['getCriteria'])
+    ...mapGetters('analysis', ['getCriteria', 'getAlternatives'])
   },
   methods: {
-    abs(val) {
-      return val < 0 ? -val : val
-    },
     handleErrors() {
       this.errors = null
     },
-    handleCriteriaPriority() {
-      const com = this.combinationArray
-      const criArray = this.getCriteria
-      const criHash = {}
-      let j, k
-      for(j = 0; j < criArray.length; j++){
-        criHash[criArray[j]] = 1
-      }
-      for(k = 0; k < com.length; k++){
-        const criLeft = com[k][0]
-        const criRight = com[k][1]
-        const value = this.inputValues[k]
-        const abs = this.abs(value - 4)
-        const score = 2 * abs + 1
-        if (value < 4) {
-          criHash[criLeft] *= score
-          criHash[criRight] *= 1 / score
-        } else {
-          criHash[criRight] *= score
-          criHash[criLeft] *= 1 / score
-        }
-      }
-      const geomeans = {}
-      let geomeanTotal = 0
-      for(let key in criHash) {
-        geomeans[key] = criHash[key] ** (1 / Object.keys(criHash).length)
-        geomeanTotal += geomeans[key]
-      }
-      const priority = {}
-      for(let key in geomeans) {
-        priority[key] = geomeans[key] / geomeanTotal
-      }
-      console.log(priority)
-      this.setPriority(priority)
+    setEvaluationDataCollection(cri, ind, arr) {
+      this.evaluationDataCollection[ind] = { criterion: cri, data: arr }
     },
-    ...mapActions('analysis', ['setPriority'])
+    handleAlternativeEvaluation() {
+      const e = this.evaluationDataCollection
+      const array = []
+      for(let i = 0; i < e.length; i++) {
+        const hash = {}
+        hash.data = this.$calculator.weightCalculation(this.getAlternatives, e[i].data)
+        hash.criterion = e[i].criterion
+        array.push(hash)
+      }
+      this.setAlternativeEvaluations(array)
+      console.log(array)
+    },
+    ...mapActions('analysis', ['setAlternativeEvaluations'])
   }
 }
 </script>

--- a/app/javascript/pages/analysis/AlternativeInput.vue
+++ b/app/javascript/pages/analysis/AlternativeInput.vue
@@ -12,15 +12,20 @@
         >
       </div>
       <div>
-        <router-link to="#" @click.native="addForm">記入欄を追加</router-link>
+        <router-link
+          to="#"
+          @click.native="addForm"
+        >
+          記入欄を追加
+        </router-link>
       </div>
-      <button
+      <router-link
         type="button"
         class="btn btn-secondary"
         to="/"
       >
         戻る
-      </button>
+      </router-link>
       <button
         type="button"
         class="btn btn-success"

--- a/app/javascript/pages/analysis/CriterionImportance.vue
+++ b/app/javascript/pages/analysis/CriterionImportance.vue
@@ -2,7 +2,10 @@
   <div class="container">
     <h3>STEP3 条件の重要性を比較してください</h3>
     <div class="col-8 offset-2">
-      <EvaluationList :combination-array="combinationArray" @catch-data="setEvaluationData"></EvaluationList>
+      <EvaluationList
+        :combination-array="combinationArray"
+        @catch-data="setEvaluationData"
+      />
       <router-link
         type="button"
         class="btn btn-secondary"
@@ -53,7 +56,7 @@ export default {
     handleCriterionImportance() {
       const array = this.$calculator.weightCalculation(this.getCriteria, this.evaluationData)
       this.setCriterionImportances(array)
-      // this.$router.push('/analysis/step4')
+      this.$router.push('/analysis/step4')
     },
     ...mapActions('analysis', ['setCriterionImportances'])
   }

--- a/app/javascript/pages/analysis/CriterionSelect.vue
+++ b/app/javascript/pages/analysis/CriterionSelect.vue
@@ -26,18 +26,18 @@
       </div>
       <div>
         <router-link
-          @click.native="addCriterion"
           to="#"
+          @click.native="addCriterion"
         >
-        条件を追加
-      </router-link>
+          条件を追加
+        </router-link>
       </div>
       <router-link
         type="button"
         class="btn btn-secondary"
         to="/analysis/step1"
       >
-      戻る
+        戻る
       </router-link>
       <button
         type="button"

--- a/app/javascript/pages/analysis/components/EvaluationItem.vue
+++ b/app/javascript/pages/analysis/components/EvaluationItem.vue
@@ -12,10 +12,10 @@
         class="input-inline"
       >
         <input
-          @change="sendValue(n)"
           type="radio"
           :name="name"
           :value="n"
+          @change="sendValue(n)"
         >
       </span>
     </div>
@@ -36,7 +36,7 @@ export default {
       required: true
     },
     name: {
-      type: Number,
+      type: String,
       required: true
     }
   },

--- a/app/javascript/pages/analysis/components/EvaluationList.vue
+++ b/app/javascript/pages/analysis/components/EvaluationList.vue
@@ -6,9 +6,9 @@
     >
       <EvaluationItem
         :combination="item"
-        :name="index"
+        :name="listName + item"
         @catch-value="sendData(index, $event)"
-      ></EvaluationItem>
+      />
     </div>
   </div>
 </template>
@@ -24,6 +24,10 @@ export default {
     combinationArray: {
       type: Array,
       required: true
+    },
+    listName: {
+      type: String,
+      required: false
     }
   },
   data() {
@@ -35,7 +39,7 @@ export default {
     sendData(ind, val) {
       let obj = {}
       obj.combination = this.combinationArray[ind]
-      obj.score = val
+      obj.value = val
       this.evaluationListData[ind] = obj
       this.$emit('catch-data', this.evaluationListData)
     }

--- a/app/javascript/plugins/calculator.js
+++ b/app/javascript/plugins/calculator.js
@@ -3,8 +3,8 @@ export default {
     const newArray = []
     let i, j
     for(i = 1; i < arr.length; i++){
-      const f = arr.slice(i-1)
-      for(j = 1; j < arr.length; j++){
+      const a = arr.slice(i-1)
+      for(j = 1; j < a.length; j++){
         newArray.push([a[0], a[j]])
       }
     }
@@ -28,7 +28,7 @@ export default {
     for(j = 0; j < evalData.length; j++) {
       const factorA = array.find(f => f.name === evalData[j].combination[0])
       const factorB = array.find(f => f.name === evalData[j].combination[1])
-      const value = evalData[j].score
+      const value = evalData[j].value
       const abs = this.abs(value - 4)
       const score = 2 * abs + 1
       if (value < 4) {

--- a/app/javascript/store/modules/analysis.js
+++ b/app/javascript/store/modules/analysis.js
@@ -2,12 +2,14 @@ import axios from '../../plugins/axios.js'
 const state = {
   alternatives: null,
   criteria: null,
-  criterionImportances: null
+  criterionImportances: null,
+  alternativeEvaluations: null
 }
 const getters = {
   getAlternatives: state => state.alternatives,
   getCriteria: state => state.criteria,
-  getCriterionImportances: state => state.criterionImportances
+  getCriterionImportances: state => state.criterionImportances,
+  getAlternativeEvaluations: state => state.alternativeEvaluations
 }
 const mutations = {
   setAlternatives(state, array) {
@@ -16,8 +18,11 @@ const mutations = {
   setCriteria(state, array) {
     state.criteria = array
   },
-  setCriterionImportances(state, hash) {
-    state.criterionImportances = hash
+  setCriterionImportances(state, array) {
+    state.criterionImportances = array
+  },
+  setAlternativeEvaluations(state, array) {
+    state.alternativeEvaluations = array
   }
 }
 const actions = {
@@ -27,8 +32,11 @@ const actions = {
   setCriteria({commit}, array) {
     commit('setCriteria', array)
   },
-  setCriterionImportances({commit}, hash) {
-    commit('setCriterionImportances', hash)
+  setCriterionImportances({commit}, array) {
+    commit('setCriterionImportances', array)
+  },
+  setAlternativeEvaluations({commit}, array) {
+    commit('setAlternativeEvaluations', array)
   }
 }
 


### PR DESCRIPTION
# Issue
#5 
# 概要
選択した評価基準ごとに就職先の選択肢を評価する機能を実装
# 変更点
選択肢評価ページ

- 選択肢評価ページのコンポーネントpages/analysis/AlternativeEvaluation.vueを作成
- #10 でコンポーネント化した評価フォームを評価基準ごとに表示
- createdフックにて、 就職先選択肢入力ページ（analysis/AlternativeInput.vue）で入力した複数の選択肢を重複のない２つずつのペアにし、dataプロパティのcombinationArrayに格納するよう記述
- 各評価基準ごとにペア間の相対評価がラジオボタンで行われると、changeイベントによって採点データがdataプロパティのevaluationDataCollectionに追加される処理を記述
- 決定ボタンでhandleAlternativeEvaluationが発火し、#10 でプラグインに記述した関数で基準ごとの就職先の評価点が算出され、評価データがVuexに送られるよう記述

```
[{ criterion: 評価基準, 
    data: [
     { name: 就職先, score:[点数], geomean: 幾何平均, weight: 評価点 }, { name: ...},...]},
 { criterion: ...,
    data: [...] } ]
```

analysisモジュール

- コンポーネントから送られてきた評価データをstate.alternativeEvaluationsとしてストアするようmutationsとactionsを記述
