### PR TITLE
#19 各ページに説明文を追加

### DIFF
--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -1,70 +1,72 @@
 <template>
   <div>
-    <v-app-bar app
+    <v-app-bar
+      app
     >
       <v-toolbar-title>
         <v-btn
-          @click="topPage"
           id="logo"
+          @click="topPage"
         >
-        Workers<span>-</span>AHP
+          Workers<span>-</span>AHP
         </v-btn>
       </v-toolbar-title>
-      <v-spacer></v-spacer>
-        <v-toolbar-items
-          v-if="isAuthenticated"
-        >
-          <v-menu offset-y>
-            <template v-slot:activator="{ on, attrs }">
+      <v-spacer />
+      <v-toolbar-items
+        v-if="isAuthenticated"
+      >
+        <v-menu offset-y>
+          <template #activator="{ on, attrs }">
+            <v-btn
+              color="secondary"
+              dark
+              v-bind="attrs"
+              v-on="on"
+              style="text-transform: none;"
+            >
+              {{ isAuthenticated.name }}
+              <v-icon>mdi-menu-down</v-icon>
+            </v-btn>
+          </template>
+          <v-list>
+            <v-list-item>
               <v-btn
-                color="secondary"
-                dark
-                v-bind="attrs"
-                v-on="on"
+                text
+                to="/mypage"
               >
-                {{ isAuthenticated.name }}
-                <v-icon>mdi-menu-down</v-icon>
+                マイページ
               </v-btn>
-            </template>
-            <v-list>
-              <v-list-item>
-                <v-btn
-                  text
-                  to="/mypage"
-                >
-                  マイページ
-                </v-btn>
-              </v-list-item>
-              <v-list-item>
-                <v-btn
-                  text
-                  to="#"
-                  @click.native="logout"
-                >
-                  ログアウト
-                </v-btn>
-              </v-list-item>
-            </v-list>
-          </v-menu>
-        </v-toolbar-items>
-        <v-toolbar-items
-          v-else
+            </v-list-item>
+            <v-list-item>
+              <v-btn
+                text
+                to="#"
+                @click.native="logout"
+              >
+                ログアウト
+              </v-btn>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+      </v-toolbar-items>
+      <v-toolbar-items
+        v-else
+      >
+        <v-btn
+          text
+          to="/register"
+          class="list-inline-item"
         >
-          <v-btn
-            text
-            to="/register"
-            class="list-inline-item"
-          >
-            ユーザー登録
-          </v-btn>
-          <v-btn
-            text
-            to="/login"
-            class="list-inline-item"
-          >
-            ログイン
-          </v-btn>
-        </v-toolbar-items>
+          ユーザー登録
+        </v-btn>
+        <v-btn
+          text
+          to="/login"
+          class="list-inline-item"
+        >
+          ログイン
+        </v-btn>
+      </v-toolbar-items>
     </v-app-bar>
   </div>
 </template>

--- a/app/javascript/pages/TopPage.vue
+++ b/app/javascript/pages/TopPage.vue
@@ -1,6 +1,10 @@
 <template>
   <v-container>
-    <v-col cols="12" md="10" class="mx-auto">
+    <v-col
+      cols="12"
+      md="10"
+      class="mx-auto"
+    >
       <h1>Workers<span>-</span>AHP</h1>
       <div class="headings">
         <h3>分かれ道のあなたへ</h3>
@@ -8,23 +12,30 @@
       </div>
       <div style="text-align:center;">
         <v-btn
-        to="/analysis/step1"
-        color="#6495ed"
-        height="70"
-        width="260"
-        id="analysis-btn"
-        dark
-        large
+          id="analysis-btn"
+          to="/analysis/step1"
+          color="#6495ed"
+          height="70"
+          width="260"
+          dark
+          large
         >
-        Start
-      </v-btn>
-    </div>
+          Start
+        </v-btn>
+      </div>
       <div class="contents">
         <v-row>
-          <v-col cols="8" md="4" class="mx-auto">
-            <v-card width="400" height="550">
-              <img src="../../assets/images/undraw_Travel_mode_re_2lxo.svg"/>
-              <v-divider></v-divider>
+          <v-col
+            cols="8"
+            md="4"
+            class="mx-auto"
+          >
+            <v-card
+              width="400"
+              height="550"
+            >
+              <img src="../../assets/images/undraw_Travel_mode_re_2lxo.svg">
+              <v-divider />
               <v-card-title>こんなあなたに</v-card-title>
               <v-card-text>
                 <div>
@@ -33,14 +44,14 @@
                     本当に納得できる就職先を選びたい
                   </span>
                 </div>
-                <p></p>
+                <p />
                 <div>
                   <v-icon>mdi-file-document-multiple-outline</v-icon>
                   <span>
                     エントリー先の優先順位をつけたい
                   </span>
                 </div>
-                <p></p>
+                <p />
                 <div>
                   <v-icon>mdi-bug</v-icon>
                   <span>
@@ -50,20 +61,34 @@
               </v-card-text>
             </v-card>
           </v-col>
-          <v-col cols="8" md="4" class="mx-auto">
-            <v-card width="400" height="550">
-              <img src="../../assets/images/undraw_Metrics_re_6g90.svg"/>
-              <v-divider></v-divider>
+          <v-col
+            cols="8"
+            md="4"
+            class="mx-auto"
+          >
+            <v-card
+              width="400"
+              height="550"
+            >
+              <img src="../../assets/images/undraw_Metrics_re_6g90.svg">
+              <v-divider />
               <v-card-title>志望度を数値化</v-card-title>
               <v-card-text>
-                企業活動や公共事業でも用いられる意思決定法「AHP」により、志望先ごとに志望度を数値化。<br />こだわり条件や求人へのイメージを反映した根拠あるデータで意思決定をサポートします。
+                企業活動や公共事業でも用いられる意思決定法「AHP」により、志望先ごとに志望度を数値化。<br>こだわり条件や求人へのイメージを反映した根拠あるデータで意思決定をサポートします。
               </v-card-text>
             </v-card>
           </v-col>
-          <v-col cols="8" md="4" class="mx-auto">
-            <v-card width="400" height="550">
-              <img src="../../assets/images/undraw_Projections_re_1mrh.svg"/>
-              <v-divider></v-divider>
+          <v-col
+            cols="8"
+            md="4"
+            class="mx-auto"
+          >
+            <v-card
+              width="400"
+              height="550"
+            >
+              <img src="../../assets/images/undraw_Projections_re_1mrh.svg">
+              <v-divider />
               <v-card-title>再利用可能な分析データ</v-card-title>
               <v-card-text>
                 保存した分析履歴を用いて再分析が可能。仕事選びにおける状況の変化に柔軟に対応します。
@@ -72,7 +97,11 @@
           </v-col>
         </v-row>
       </div>
-      <v-col cols="12" md="10" class="mx-auto">
+      <v-col
+        cols="12"
+        md="10"
+        class="mx-auto"
+      >
         <v-expansion-panels>
           <v-expansion-panel depressed>
             <v-expansion-panel-header>
@@ -140,7 +169,7 @@
                   優先度と相対評点を用いて各代替案の総合評点を求め、最も評点の高い代替案を選択する
                 </li>
               </ol>
-              <v-img src="https://i.gyazo.com/1247472500567252cb2c0370609f634c.png"/>
+              <v-img src="https://i.gyazo.com/1247472500567252cb2c0370609f634c.png" />
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-expansion-panels>

--- a/app/javascript/pages/analysis/AlternativeEvaluation.vue
+++ b/app/javascript/pages/analysis/AlternativeEvaluation.vue
@@ -1,26 +1,38 @@
 <template>
   <v-container>
     <v-row>
-      <v-col cols="12" offset-md="2" md="8">
-        <h3>STEP4 条件ごとにどちらの就職先が優れているか比較してください</h3>
-        <template v-if="errors">
-          <ErrorMessage
-            :messages="errors"
-          />
-        </template>
+      <v-col
+        cols="12"
+        lg="8"
+        class="mx-auto"
+      >
+        <h3>STEP4 どちらの選択肢が優れているか比較してください</h3>
+        <v-col align="center">
+          <p>
+            それぞれの評価基準において、どの選択肢がどの程度優れているかを数値化します。<br>
+            それぞれの評価基準のもとで2つの選択肢を比較し、当てはまる数字を選んでください。<br>
+          </p>
+          <HowToCompare type="evaluation" />
+        </v-col>
         <div
           v-for="(item, index) in getCriteria"
           :key="index"
+          class="mb-15"
         >
-          <div>
+          <h3>
             {{ item }}
-          </div>
+          </h3>
           <EvaluationList
             :factors="getAlternatives"
             :list-number="index"
             @catch-data="setEvaluationDataCollection(item, index, $event)"
           />
         </div>
+        <template v-if="errors">
+          <ErrorMessage
+            :messages="errors"
+          />
+        </template>
         <TheButtons
           preview-page-path="/analysis/step3"
           @ok-button="handleAlternativeEvaluation"
@@ -34,12 +46,14 @@
 import { mapActions } from 'vuex'
 import { mapGetters } from 'vuex'
 import EvaluationList from './components/EvaluationList.vue'
+import HowToCompare from './components/HowToCompare.vue'
 import TheButtons from './components/TheButtons.vue'
 import ErrorMessage from '../../components/ErrorMessage.vue'
 export default {
   name: 'AlternativeEvaluation',
   components: {
     EvaluationList,
+    HowToCompare,
     TheButtons,
     ErrorMessage
   },
@@ -80,10 +94,8 @@ export default {
 h3 {
   margin: 50px auto;
 }
-input {
-  margin-bottom: 10px;
-}
-.col {
+.number-rule {
   text-align: center;
+  margin-top: 40px;
 }
 </style>

--- a/app/javascript/pages/analysis/AlternativeInput.vue
+++ b/app/javascript/pages/analysis/AlternativeInput.vue
@@ -2,11 +2,6 @@
   <div class="container">
     <div class="col-8 offset-2 alternative-forms">
       <h3>STEP1 就職先の選択肢を入力してください</h3>
-      <template v-if="errors">
-        <ErrorMessage
-          :messages="errors"
-        />
-      </template>
       <div
         v-for="(item, index) in alternatives"
         :key="index"
@@ -14,7 +9,7 @@
         <input
           :id="'alternative' + index"
           v-model="alternatives[index]"
-          class="form-control"
+          class="form-control mb-3"
         >
       </div>
       <div>
@@ -25,6 +20,11 @@
           記入欄を追加
         </router-link>
       </div>
+      <template v-if="errors">
+        <ErrorMessage
+          :messages="errors"
+        />
+      </template>
       <TheButtons
         preview-page-path="/"
         @ok-button="handleAlternative"
@@ -70,8 +70,5 @@ export default {
 <style scoped>
 h3 {
   margin: 50px auto;
-}
-input {
-  margin-bottom: 10px;
 }
 </style>

--- a/app/javascript/pages/analysis/CriterionImportance.vue
+++ b/app/javascript/pages/analysis/CriterionImportance.vue
@@ -1,17 +1,28 @@
 <template>
   <v-container>
     <v-row>
-      <v-col cols="12" lg="8" class="mx-auto">
-        <h3>STEP3 条件の重要性を比較してください</h3>
+      <v-col
+        cols="12"
+        lg="8"
+        class="mx-auto"
+      >
+        <h3>STEP3 評価基準の重要性を比較してください</h3>
+        <v-col align="center">
+          <p>
+            STEP2で選んだそれぞれの評価基準をあなたがどの程度重要視しているかを数値化します。<br>
+            2つの評価基準の重要度を比較し、当てはまる数字を選んでください。<br>
+          </p>
+          <HowToCompare type="importance" />
+        </v-col>
+        <EvaluationList
+          :factors="getCriteria"
+          @catch-data="setEvaluationData"
+        />
         <template v-if="errors">
           <ErrorMessage
             :messages="errors"
           />
         </template>
-        <EvaluationList
-          :factors="getCriteria"
-          @catch-data="setEvaluationData"
-        />
         <TheButtons
           preview-page-path="/analysis/step2"
           @ok-button="handleCriterionImportance"
@@ -25,12 +36,14 @@
 import { mapActions } from 'vuex'
 import { mapGetters } from 'vuex'
 import EvaluationList from './components/EvaluationList.vue'
+import HowToCompare from './components/HowToCompare.vue'
 import TheButtons from './components/TheButtons.vue'
 import ErrorMessage from '../../components/ErrorMessage.vue'
 export default {
   name: 'CriterionImportance',
   components: {
     EvaluationList,
+    HowToCompare,
     TheButtons,
     ErrorMessage
   },
@@ -64,11 +77,5 @@ export default {
 <style scoped>
 h3 {
   margin: 50px auto;
-}
-input {
-  margin-bottom: 10px;
-}
-.col {
-  text-align: center;
 }
 </style>

--- a/app/javascript/pages/analysis/CriterionSelect.vue
+++ b/app/javascript/pages/analysis/CriterionSelect.vue
@@ -1,42 +1,42 @@
 <template>
-  <div class="container">
-    <div class="col-8 offset-2">
-      <h3>STEP2 就職先を決める上で考慮する条件を選んでください</h3>
-      <template v-if="errors">
-        <ErrorMessage
-          :messages="errors"
-        />
-      </template>
-      <div
-        v-for="(item, index) in criteria"
-        :key="item"
-      >
+  <v-container>
+    <v-row justify="center">
+      <v-col cols="8">
+        <h3>STEP2 就職先を決める上での評価基準を選んでください</h3>
         <v-checkbox
-          color="orange"
+          v-for="(item, index) in criteria"
           :id="'criterion' + index"
+          :key="item"
           v-model="selectedCriteria"
+          color="orange"
           :value="item"
           :label="item"
-        ></v-checkbox>
-      </div>
-      <div class="input-group">
-        <input
-          v-model="addedCriteria"
-          class="form-control"
-          placeholder="追加したい条件を記入"
-        >
-        <v-btn
-          @click.native="addCriterion"
-        >
-          条件を追加
-        </v-btn>
-      </div>
-      <TheButtons
-        preview-page-path="/analysis/step1"
-        @ok-button="handleSelectedCriteria"
-      />
-    </div>
-  </div>
+          class="mt-0"
+        />
+        <div class="input-group">
+          <input
+            v-model="addedCriteria"
+            class="form-control"
+            placeholder="追加したい条件を記入"
+          >
+          <v-btn
+            @click.native="addCriterion"
+          >
+            条件を追加
+          </v-btn>
+        </div>
+        <template v-if="errors">
+          <ErrorMessage
+            :messages="errors"
+          />
+        </template>
+        <TheButtons
+          preview-page-path="/analysis/step1"
+          @ok-button="handleSelectedCriteria"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
@@ -100,11 +100,5 @@ export default {
 <style scoped>
 h3 {
   margin: 50px auto;
-}
-.v-input {
-  margin-top: 0;
-}
-.buttons {
-  margin-top: 10px;
 }
 </style>

--- a/app/javascript/pages/analysis/Result.vue
+++ b/app/javascript/pages/analysis/Result.vue
@@ -2,6 +2,12 @@
   <div class="container">
     <div class="col-8 offset-2">
       <h3>結果</h3>
+      <v-col align="center">
+        <p>
+          おつかれさまでした！<br>
+          決定ボタンを押して結果を表示してください。
+        </p>
+      </v-col>
       <ResultGraph
         v-if="graph"
         :chart-data="chartData"
@@ -52,11 +58,5 @@ export default {
 <style scoped>
 h3 {
   margin: 50px auto;
-}
-input {
-  margin-bottom: 10px;
-}
-.col {
-  text-align: center;
 }
 </style>

--- a/app/javascript/pages/analysis/components/EvaluationItem.vue
+++ b/app/javascript/pages/analysis/components/EvaluationItem.vue
@@ -4,14 +4,17 @@
       rounded
       elevation="2"
       class="text-center"
-      style="margin: 20px auto;"
+      style="margin: 30px auto;"
     >
       <div>
         <v-row>
           <v-col cols="3">
             {{ combination[0] }}
           </v-col>
-          <v-col cols="3" class="ml-auto">
+          <v-col
+            cols="3"
+            class="ml-auto"
+          >
             {{ combination[1] }}
           </v-col>
         </v-row>
@@ -23,11 +26,14 @@
               tile
               borderless
               color="deep-purple accent-3"
-              >
+              :name="name"
+            >
               <v-btn
                 v-for="n in 7"
                 :key="n"
+                :id="n"
                 elevation="4"
+                class="mr-1"
                 @click="sendValue(n)"
               >
                 {{ n }}
@@ -53,6 +59,19 @@ export default {
       required: true
     }
   },
+  // data() {
+  //   return {
+  //     btnLabel: [
+  //       '≫',
+  //       '>',
+  //       '≥',
+  //       '=',
+  //       '≤',
+  //       '<',
+  //       '≪'
+  //     ]
+  //   }
+  // },
   methods: {
     sendValue(val) {
       this.$emit('catch-value', val)
@@ -62,7 +81,4 @@ export default {
 </script>
 
 <style scoped>
-button {
-  margin-right: 5px;
-}
 </style>

--- a/app/javascript/pages/analysis/components/HowToCompare.vue
+++ b/app/javascript/pages/analysis/components/HowToCompare.vue
@@ -1,0 +1,134 @@
+<template>
+  <v-dialog
+    width="500"
+    hide-overlay
+  >
+    <v-card>
+      <v-col align="center">
+        <p>
+          on-mouse!
+        </p>
+        <v-btn-toggle
+          borderless
+          tile
+          color="deep-purple accent-3"
+          name="#"
+        >
+          <v-tooltip
+            v-for="n in 7"
+            :key="n"
+            bottom
+          >
+            <template #activator="{ on, attrs }">
+              <v-btn
+                v-bind="attrs"
+                class="mr-1"
+                elevation="4"
+                v-on="on"
+              >
+                {{ n }}
+              </v-btn>
+            </template>
+            {{ tooltip[n-1] }}
+          </v-tooltip>
+          <v-tooltip bottom>
+            <template #activator="{ on, attrs }">
+              <v-icon
+                class="ml-3"
+                v-bind="attrs"
+                v-on="on"
+              >
+                mdi-head-question-outline
+              </v-icon>
+            </template>
+            <v-card width="600">
+              <v-col>
+                <p>
+                  {{ tooltipDescription }}
+                </p>
+                <v-img :src="tooltipImg" />
+              </v-col>
+            </v-card>
+          </v-tooltip>
+        </v-btn-toggle>
+      </v-col>
+    </v-card>
+    <template #activator="{ on, attrs }">
+      <v-btn
+        color="red lighten-2"
+        dark
+        v-bind="attrs"
+        v-on="on"
+      >
+        Help
+      </v-btn>
+    </template>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: 'HowToEvaluation',
+  props: {
+    type: {
+      type: String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      tooltipImp: [
+        '左側がとても重要',
+        '左側が重要',
+        '左側がやや重要',
+        '両方同じくらい重要',
+        '右側がやや重要',
+        '右側が重要',
+        '右側がとても重要'
+      ],
+      tooltipEval: [
+        '左側がとても優れている',
+        '左側が優れている',
+        '左側がやや優れている',
+        '同程度',
+        '右側がやや優れている',
+        '右側が優れている',
+        '右側がとても優れている'
+      ],
+      tooltipImgImp: 'https://i.gyazo.com/b245b040c198967969f8819e201edc3f.png',
+      tooltipImgEval: 'https://i.gyazo.com/6df413eb6a048f8dca2df5b18d6241b2.png',
+      tooltipDescriptionImp: '労働時間が通勤時間よりやや重要であるとき',
+      tooltipDescriptionEval: '労働時間においてA社がB社より優れているとき'
+    }
+  },
+  computed: {
+    tooltip() {
+      if (this.type === 'importance') {
+        return this.tooltipImp
+      } else {
+        return this.tooltipEval
+      }
+    },
+    tooltipImg() {
+      if (this.type === 'importance') {
+        return this.tooltipImgImp
+      } else {
+        return this.tooltipImgEval
+      }
+    },
+    tooltipDescription() {
+      if (this.type === 'importance') {
+        return this.tooltipDescriptionImp
+      } else {
+        return this.tooltipDescriptionEval
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+h3 {
+  margin: 50px auto;
+}
+</style>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,6 +40,6 @@ RSpec.describe User, type: :model do
   it 'パスワードとパスワード（確認）が異なるとき無効' do
     user = build(:user, password_confirmation: '00000000')
     user.valid?
-    expect(user.errors[:password_confirmation]).to include('とPasswordの入力が一致しません')
+    expect(user.errors[:password_confirmation]).to include('とパスワードの入力が一致しません')
   end
 end

--- a/spec/support/analysis_macros.rb
+++ b/spec/support/analysis_macros.rb
@@ -8,7 +8,7 @@ module AnalysisMacros
 
   def criterion_select(number)
     number.times do |n|
-      check("criterion#{n}")
+      check("criterion#{n}", allow_label_click: true)
     end
     click_on '決定'
   end
@@ -19,7 +19,7 @@ module AnalysisMacros
       i += j
     end
     i.times do |n|
-      find("span[class='0-#{n}']").choose("0")
+      find("div[name='0-#{n}']").click
     end
     click_on '決定'
   end
@@ -31,7 +31,7 @@ module AnalysisMacros
     end
     criterion_number.times do |m|
       i.times do |n|
-        find("span[class='#{m}-#{n}']").choose("0")
+        find("div[name='#{m}-#{n}']").click
       end
     end
     click_on '決定'

--- a/spec/system/analysis_spec.rb
+++ b/spec/system/analysis_spec.rb
@@ -4,42 +4,86 @@ RSpec.describe 'Analysis', type: :system do
   let(:criterion_number) { 3 }
   let(:alternative_number) { 3 }
   describe 'STEP1' do
+    before { visit '/analysis/step1' }
+    it '入力された就職先が2つ以上のとき次ページに遷移する' do
+      find('#alternative0').set('company0')
+      find('#alternative1').set('company1')
+      click_on '決定'
+      expect(page).to have_current_path('/analysis/step2'), '次ページに遷移していません'
+    end
+
     it '入力された就職先が2つ未満のときエラーメッセージが表示される' do
-      visit '/analysis/step1'
       find('#alternative0').set('company0')
       click_on '決定'
-      expect(page).to have_selector('.alert')
+      expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
     end
   end
 
   describe 'STEP2' do
-    it '条件が2つ以上選択されていないときエラーメッセージが表示される' do
+    before do
       visit '/analysis/step1'
       alternative_input(alternative_number)
-      check('criterion0')
+    end
+    it '条件が2つ以上選択されているとき次ページに遷移する' do
+      check('criterion0', allow_label_click: true)
+      check('criterion1', allow_label_click: true)
       click_on '決定'
-      expect(page).to have_selector('.alert')
+      expect(page).to have_current_path('/analysis/step3'), '次ページに遷移していません'
+    end
+
+    it '条件が2つ以上選択されていないときエラーメッセージが表示される' do
+      check('criterion0', allow_label_click: true)
+      click_on '決定'
+      expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
     end
   end
 
   describe 'STEP3' do
-    it 'ラジオボタンがすべて押されていないときエラーメッセージが表示される' do
+    before do
       visit '/analysis/step1'
       alternative_input(alternative_number)
       criterion_select(criterion_number)
+    end
+    it 'ラジオボタンがすべて押されているとき次ページに遷移する' do
+      criterion_importance(criterion_number)
+      expect(page).to have_current_path('/analysis/step4'), '次ページに遷移していません'
+    end
+
+    it 'ラジオボタンがすべて押されていないときエラーメッセージが表示される' do
       criterion_importance(criterion_number-1)
-      expect(page).to have_selector('.alert')
+      expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
     end
   end
 
   describe 'STEP4' do
-    it "ラジオボタンがすべて押されていないときエラーメッセージが出る" do
+    before do
       visit '/analysis/step1'
       alternative_input(alternative_number)
       criterion_select(criterion_number)
       criterion_importance(criterion_number)
+    end
+    it "ラジオボタンがすべて押されているとき次ページに遷移する" do
+      alternative_evaluation(criterion_number, alternative_number)
+      expect(page).to have_current_path('/analysis/result'), '次ページに遷移していません'
+    end
+
+    it "ラジオボタンがすべて押されていないときエラーメッセージが出る" do
       alternative_evaluation(criterion_number, alternative_number-1)
-      expect(page).to have_selector('.alert')
+      expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
+    end
+  end
+
+  describe 'Result' do
+    before do
+      visit '/analysis/step1'
+      alternative_input(alternative_number)
+      criterion_select(criterion_number)
+      criterion_importance(criterion_number)
+      alternative_evaluation(criterion_number, alternative_number)
+    end
+    it '決定ボタンを押すと結果が表示される' do
+      click_on '決定'
+      expect(page).to have_selector('#bar-chart'), '結果が表示されていません'
     end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'User', type: :system do
       within "#register-form" do
         click_on '登録'
       end
-      expect(page).to have_css('li.alert'), 'エラーメッセージが表示されていません'
+      expect(page).to have_css('li.error-message'), 'エラーメッセージが表示されていません'
     end
   end
 
@@ -34,14 +34,14 @@ RSpec.describe 'User', type: :system do
 
     it 'ログイン状態によってヘッダーの表示が変わる' do
       visit '/'
-      expect(page).to have_selector('.navbar'), text: 'ログイン'
+      expect(page).to have_content('ログイン')
       visit '/login'
       within "#login-form" do
         fill_in 'メールアドレス', with: user.email
         fill_in 'パスワード', with: password
         click_on 'ログイン'
       end
-      expect(page).to have_selector('.navbar', text: user.name), 'ログインできていません'
+      expect(page).to have_content(user.name), 'ヘッダーの表示が変わっていません'
     end
 
     it 'ログインページで各フィールドに入力し「ログイン」を押すとログインできる' do
@@ -51,7 +51,7 @@ RSpec.describe 'User', type: :system do
         fill_in 'パスワード', with: password
         click_on 'ログイン'
       end
-      expect(page).to have_selector('.navbar', text: user.name), 'ログインできていません'
+      expect(page).to have_content(user.name), 'ログインできていません'
       expect(page).to have_current_path('/'), 'トップページに遷移できていません'
     end
 
@@ -60,7 +60,7 @@ RSpec.describe 'User', type: :system do
       within "#login-form" do
         click_on 'ログイン'
       end
-      expect(page).to have_css('li.alert'), 'エラーメッセージが表示されていません'
+      expect(page).to have_css('li.error-message'), 'エラーメッセージが表示されていません'
     end
   end
 end


### PR DESCRIPTION
# issue
#19 
# 概要
分析用の各ページに説明文を追加
# 変更点
分析STEP3, STEP4のページに説明文を追加
pages/analysis/components/HowToCompare.vueを作成し、ダイアログ内のボタンにオンマウスするとボタンの数字の意味が表示されるよう記述
分析STEP3, STEP4のページ内にHELPボタンを設置し、押すとHowToCompareのダイアログが表示されるよう実装