### PR TITLE
#26 分析ページで以前の入力値を取得

### DIFF
--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -21,8 +21,8 @@
               color="secondary"
               dark
               v-bind="attrs"
-              v-on="on"
               style="text-transform: none;"
+              v-on="on"
             >
               {{ isAuthenticated.name }}
               <v-icon>mdi-menu-down</v-icon>

--- a/app/javascript/pages/TopPage.vue
+++ b/app/javascript/pages/TopPage.vue
@@ -41,21 +41,21 @@
                 <div>
                   <v-icon>mdi-hexagon-multiple-outline</v-icon>
                   <span>
-                    本当に納得できる就職先を選びたい
+                    複数の求人で迷っている
                   </span>
                 </div>
                 <p />
                 <div>
                   <v-icon>mdi-file-document-multiple-outline</v-icon>
                   <span>
-                    エントリー先の優先順位をつけたい
+                    エントリー先の優先順位を決めたい
                   </span>
                 </div>
                 <p />
                 <div>
                   <v-icon>mdi-bug</v-icon>
                   <span>
-                    迷いを断ち切りたい...
+                    将来への迷いを断ち切りたい...
                   </span>
                 </div>
               </v-card-text>
@@ -72,9 +72,9 @@
             >
               <img src="../../assets/images/undraw_Metrics_re_6g90.svg">
               <v-divider />
-              <v-card-title>志望度を数値化</v-card-title>
+              <v-card-title>あなたの志望度を数値化</v-card-title>
               <v-card-text>
-                企業活動や公共事業でも用いられる意思決定法「AHP」により、志望先ごとに志望度を数値化。<br>こだわり条件や求人へのイメージを反映した根拠あるデータで意思決定をサポートします。
+                企業活動や公共事業でも用いられる意思決定法「AHP」により、志望先ごとに志望度を数値化。<br>あなたの働く上でのこだわり条件や企業イメージを反映した根拠あるデータで意思決定をサポートします。
               </v-card-text>
             </v-card>
           </v-col>
@@ -89,7 +89,7 @@
             >
               <img src="../../assets/images/undraw_Projections_re_1mrh.svg">
               <v-divider />
-              <v-card-title>再利用可能な分析データ</v-card-title>
+              <v-card-title>それでも迷ったら...</v-card-title>
               <v-card-text>
                 保存した分析履歴を用いて再分析が可能。仕事選びにおける状況の変化に柔軟に対応します。
               </v-card-text>
@@ -174,9 +174,6 @@
           </v-expansion-panel>
         </v-expansion-panels>
       </v-col>
-      <!-- <div class="headings">
-        <h6>納得の仕事選びを。</h6>
-      </div> -->
     </v-col>
   </v-container>
 </template>

--- a/app/javascript/pages/analysis/AlternativeEvaluation.vue
+++ b/app/javascript/pages/analysis/AlternativeEvaluation.vue
@@ -6,11 +6,11 @@
         lg="8"
         class="mx-auto"
       >
-        <h3>STEP4 どちらの選択肢が優れているか比較してください</h3>
+        <h3>STEP4 条件ごとに会社を評価してください</h3>
         <v-col align="center">
           <p>
-            それぞれの評価基準において、どの選択肢がどの程度優れているかを数値化します。<br>
-            それぞれの評価基準のもとで2つの選択肢を比較し、当てはまる数字を選んでください。<br>
+            あなたが考えている選択肢がどの程度条件を満たしているかを数値化します。<br>
+            それぞれの観点で2つの選択肢同士を比較し、当てはまる数字を選んでください。<br>
           </p>
           <HowToCompare type="evaluation" />
         </v-col>
@@ -25,7 +25,7 @@
           <EvaluationList
             :factors="getAlternatives"
             :list-number="index"
-            @catch-data="setEvaluationDataCollection(item, index, $event)"
+            @catch-data="setEvalDataCollection(item, index, $event)"
           />
         </div>
         <template v-if="errors">
@@ -59,7 +59,8 @@ export default {
   },
   data() {
     return {
-      evaluationDataCollection: [],
+      evalDataCollection: [],
+      rawDataCollection: [],
       errors: null
     }
   },
@@ -67,19 +68,23 @@ export default {
     ...mapGetters('analysis', ['getCriteria', 'getAlternatives'])
   },
   methods: {
-    setEvaluationDataCollection(cri, ind, arr) {
-      this.evaluationDataCollection[ind] = { criterion: cri, data: arr }
+    setEvalDataCollection(cri, ind, arr) {
+      this.rawDataCollection[ind] = [].concat(arr)
+      this.evalDataCollection[ind] = { criterion: cri, data: arr }
     },
     handleAlternativeEvaluation() {
-      const l = this.evaluationDataCollection.filter(v => v).length
+      const l = this.evalDataCollection.filter(v => v).length
       if (l == this.getCriteria.length) {
-        const array = this.evaluationDataCollection.map(f => {
+        const raw = [].concat(this.rawDataCollection)
+        const ev = this.evalDataCollection.map(f => {
           const hash = {}
           hash.data = this.$calculator.weightCalculation(this.getAlternatives, f.data)
           hash.criterion = f.criterion
           return hash
         })
-        this.setAlternativeEvaluations(array)
+        console.log(raw)
+        console.log(ev)
+        this.setAlternativeEvaluations({eval:ev, raw:raw})
         this.$router.push('/analysis/result')
       } else {
         this.errors = ['未入力の項目があります']

--- a/app/javascript/pages/analysis/AlternativeInput.vue
+++ b/app/javascript/pages/analysis/AlternativeInput.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="container">
     <div class="col-8 offset-2 alternative-forms">
-      <h3>STEP1 就職先の選択肢を入力してください</h3>
+      <h3>STEP1 現状の選択肢を教えてください</h3>
+      <v-col align="center">
+        <p>
+          あなたが今考えている会社名や求人などを記入してください。
+        </p>
+      </v-col>
       <div
         v-for="(item, index) in alternatives"
         :key="index"
@@ -50,13 +55,13 @@ export default {
       errors: null
     }
   },
+  computed: {
+    ...mapGetters('analysis', ['getAlternatives'])
+  },
   created() {
     if (this.getAlternatives) {
       this.alternatives = this.getAlternatives
     }
-  },
-  computed: {
-    ...mapGetters('analysis', ['getAlternatives'])
   },
   methods: {
     addForm() {

--- a/app/javascript/pages/analysis/CriterionImportance.vue
+++ b/app/javascript/pages/analysis/CriterionImportance.vue
@@ -6,11 +6,11 @@
         lg="8"
         class="mx-auto"
       >
-        <h3>STEP3 評価基準の重要性を比較してください</h3>
+        <h3>STEP3 条件の重要性を比較してください</h3>
         <v-col align="center">
           <p>
-            STEP2で選んだそれぞれの評価基準をあなたがどの程度重要視しているかを数値化します。<br>
-            2つの評価基準の重要度を比較し、当てはまる数字を選んでください。<br>
+            STEP2で選んだそれぞれの条件に対するあなたのこだわりを数値化します。<br>
+            2つの評価基準のどちらをあなたが重要と考えているか比較し、当てはまる数字を選んでください。<br>
           </p>
           <HowToCompare type="importance" />
         </v-col>
@@ -60,10 +60,11 @@ export default {
     setEvaluationData(arr) {
       this.evaluationData = arr
     },
-    handleCriterionImportance() {
+    async handleCriterionImportance() {
       if (this.evaluationData) {
-        const array = this.$calculator.weightCalculation(this.getCriteria, this.evaluationData)
-        this.setCriterionImportances(array)
+        const raw = [].concat(this.evaluationData)
+        const imp = this.$calculator.weightCalculation(this.getCriteria, this.evaluationData)
+        this.setCriterionImportances({imp:imp, raw:raw})
         this.$router.push('/analysis/step4')
       } else {
         this.errors = ['未入力の項目があります']

--- a/app/javascript/pages/analysis/CriterionSelect.vue
+++ b/app/javascript/pages/analysis/CriterionSelect.vue
@@ -2,7 +2,12 @@
   <v-container>
     <v-row justify="center">
       <v-col cols="8">
-        <h3>STEP2 就職先を決める上での評価基準を選んでください</h3>
+        <h3>STEP2 こだわり条件を教えてください</h3>
+        <v-col align="center">
+          <p>
+            あなたが就職先を決める上で考慮する条件にチェックをつけてください。
+          </p>
+        </v-col>
         <v-checkbox
           v-for="(item, index) in criteria"
           :id="'criterion' + index"
@@ -72,17 +77,14 @@ export default {
       errors: null
     }
   },
+  computed: {
+    ...mapGetters('analysis', ['getAlternatives', 'getCriteria'])
+  },
   created() {
     if (this.getCriteria) {
       this.selectedCriteria = this.getCriteria
       this.criteria = this.criteria.concat(this.getCriteria.filter(f => !this.criteria.includes(f)))
     }
-  },
-  computed: {
-    fetchAlternative() {
-      return this.getAlternatives
-    },
-    ...mapGetters('analysis', ['getAlternatives', 'getCriteria'])
   },
   methods: {
     addCriterion() {

--- a/app/javascript/pages/analysis/components/EvaluationItem.vue
+++ b/app/javascript/pages/analysis/components/EvaluationItem.vue
@@ -3,8 +3,7 @@
     <v-card
       rounded
       elevation="2"
-      class="text-center"
-      style="margin: 30px auto;"
+      class="text-center my-8"
     >
       <div>
         <v-row>
@@ -31,8 +30,8 @@
             >
               <v-btn
                 v-for="n in 7"
-                :key="n"
                 :id="n"
+                :key="n"
                 :value="n"
                 elevation="4"
                 class="mr-1"
@@ -48,6 +47,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 export default {
   name: 'EvaluationItem',
   props: {
@@ -65,8 +65,20 @@ export default {
       value: null
     }
   },
+  computed: {
+    ...mapGetters('analysis', ['getImpRawData', 'getEvalRawData'])
+  },
   watch: {
     value: 'sendValue'
+  },
+  created() {
+    const m = this.name.substr(0, this.name.indexOf('-'))
+    const n = this.name.substring(this.name.indexOf('-')+1, this.name.length)
+    if (this.getImpRawData && this.$route.path === '/analysis/step3') {
+        this.value = this.getImpRawData[n]
+    } else if ( this.getEvalRawData && this.$route.path === '/analysis/step4') {
+        this.value = this.getEvalRawData[m][n]
+    }
   },
   methods: {
     sendValue() {

--- a/app/javascript/pages/analysis/components/EvaluationList.vue
+++ b/app/javascript/pages/analysis/components/EvaluationList.vue
@@ -52,6 +52,7 @@ export default {
       this.evalListData[ind] = val
       if (this.isInputDataEnough(this.evalListData)) {
         this.$emit('catch-data', this.evalListData)
+        console.log(this.evalListData)
       }
     }
   }

--- a/app/javascript/store/modules/analysis.js
+++ b/app/javascript/store/modules/analysis.js
@@ -3,13 +3,17 @@ const state = {
   alternatives: null,
   criteria: null,
   criterionImportances: null,
-  alternativeEvaluations: null
+  impRawData: null,
+  alternativeEvaluations: null,
+  evalRawData: null
 }
 const getters = {
   getAlternatives: state => state.alternatives,
   getCriteria: state => state.criteria,
   getCriterionImportances: state => state.criterionImportances,
-  getAlternativeEvaluations: state => state.alternativeEvaluations
+  getImpRawData: state => state.impRawData,
+  getAlternativeEvaluations: state => state.alternativeEvaluations,
+  getEvalRawData: state => state.evalRawData
 }
 const mutations = {
   setAlternatives(state, array) {
@@ -21,8 +25,14 @@ const mutations = {
   setCriterionImportances(state, array) {
     state.criterionImportances = array
   },
+  setImpRawData(state, array) {
+    state.impRawData = array
+  },
   setAlternativeEvaluations(state, array) {
     state.alternativeEvaluations = array
+  },
+  setEvalRawData(state, array) {
+    state.evalRawData = array
   }
 }
 const actions = {
@@ -32,11 +42,13 @@ const actions = {
   setCriteria({commit}, array) {
     commit('setCriteria', array)
   },
-  setCriterionImportances({commit}, array) {
-    commit('setCriterionImportances', array)
+  setCriterionImportances({commit}, hash) {
+    commit('setCriterionImportances', hash.imp)
+    commit('setImpRawData', hash.raw)
   },
-  setAlternativeEvaluations({commit}, array) {
-    commit('setAlternativeEvaluations', array)
+  setAlternativeEvaluations({commit}, hash) {
+    commit('setAlternativeEvaluations', hash.eval)
+    commit('setEvalRawData', hash.raw)
   }
 }
 


### PR DESCRIPTION
# Issue
#26 
# 概要
分析ページで戻るボタンを押して前の画面に戻ったときに前回入力した値をフォームやチェックボックスやボタンに反映させる機能
# 変更点
AlternativeInput.vue
- mapGettersでstate.alternativesを取得し、v-modelでフォームにバインド

CriterionSelect.vue
- mapGettresでstate.criteriaを取得し、v-modelでチェックボックスにバインド

CriterionImportance.vue
- 重要度データをVuexに保存するタイミングで、EvaluationListによってつけられた素点をstate.impRawDataとしてVuexに保存

AlternativeEvalation.vue
- 上に同じく、評価データをVuexに保存するタイミングで、素点をstate.evalRawDataとしてVuexに保存

EvaluationItem
- 親コンポーネントから渡されているnameの値を使ってstate.imp(eval)RawDataのデータセットの中から所定の評点を取得