### PR TITLE
#28 円グラフと総合評点表の値の小数点の桁数を指定

### DIFF
--- a/app/javascript/components/DoughnutGraph.vue
+++ b/app/javascript/components/DoughnutGraph.vue
@@ -25,9 +25,10 @@ export default {
               weight: 'bold',
               size: 12,
             },
+            textAlign: 'center',
             formatter: (value, ctx) => {
               const label = ctx.chart.data.labels[ctx.dataIndex]
-              return `${label}\n${value * 100 + '%'}`
+              return `${label}\n${(value * 100).toFixed(1) + '%'}`
             }
           }
         },

--- a/app/javascript/pages/analysis/Result.vue
+++ b/app/javascript/pages/analysis/Result.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row>
-      <v-col cols="12" lg="8" class="mx-auto">
+      <v-col cols="12">
         <h3>結果</h3>
         <v-row>
           <v-col align="center">
@@ -12,14 +12,14 @@
           </v-col>
         </v-row>
         <v-row>
-          <v-col cols="12" lg="8">
+          <v-col cols="12" md="8">
             <BarGraph
               v-if="chart"
               :chart-data="barChartData"
               title="総合評点"
             />
           </v-col>
-          <v-col cols="12" lg="4" class="ml-auto my-auto">
+          <v-col cols="8" md="4" class="ml-auto my-auto">
             <DoughnutGraph
               v-if="chart"
               :chart-data="doughnutChartData"

--- a/app/javascript/pages/analysis/components/DataTable.vue
+++ b/app/javascript/pages/analysis/components/DataTable.vue
@@ -29,7 +29,7 @@ export default {
       type: Array,
       required: true
     }
-  },
+  }
 }
 </script>
 

--- a/app/javascript/plugins/calculator.js
+++ b/app/javascript/plugins/calculator.js
@@ -71,8 +71,9 @@ export default {
       const d = altEval[i].data
       for (j = 0; j < d.length; j++) {
         const a = array.find(arr => arr.name === d[j].name)
-        a.result[altEval[i].criterion] = d[j].weight * criweight
-        a.total += d[j].weight * criweight
+        const weight = parseFloat((d[j].weight * criweight).toFixed(3))
+        a.result[altEval[i].criterion] = weight
+        a.total += weight
       }
     }
     return array

--- a/app/javascript/plugins/chart.js
+++ b/app/javascript/plugins/chart.js
@@ -43,7 +43,7 @@ export default {
     })
     array.unshift({ text: '要素名', value: 'name', width: '150px'})
     array.push(
-      { text: '総合評点', value: 'total', width: '150px'}
+      { text: '総合評点', value: 'total', width: '150px', align: 'center'}
     )
     return array
   },


### PR DESCRIPTION
# Issue
#28 
# 概要
円グラフのラベル内の値の表示を小数点第一位までに指定
総合評点表に使用する値を小数点第三位までに指定
# 変更点
円グラフ
- DoughnutGraphGraph.vueのformatter関数内でtoFixedにより表示する値を小数点第一位までに指定

総合評点表
- calculator.jsのresultCalculationメソッドでtoFixedにより結果のハッシュに格納する値を小数点第三位までに指定