### PR TITLE
#26 Fix:選択肢と評価基準に変更があった場合以前の評点を取得しないよう変更

### DIFF
--- a/app/javascript/pages/analysis/AlternativeEvaluation.vue
+++ b/app/javascript/pages/analysis/AlternativeEvaluation.vue
@@ -84,7 +84,7 @@ export default {
         })
         console.log(raw)
         console.log(ev)
-        this.setAlternativeEvaluations({eval:ev, raw:raw})
+        this.setAlternativeEvaluations({eval: ev, raw: raw})
         this.$router.push('/analysis/result')
       } else {
         this.errors = ['未入力の項目があります']

--- a/app/javascript/pages/analysis/AlternativeInput.vue
+++ b/app/javascript/pages/analysis/AlternativeInput.vue
@@ -67,6 +67,9 @@ export default {
     if (this.getAlternatives) {
       this.alternatives = this.getAlternatives
     }
+    this.$watch('alternatives', function() {
+      this.setAlternativeEvaluations({eval: null, raw: null})
+    })
   },
   methods: {
     addForm() {
@@ -81,7 +84,7 @@ export default {
         this.errors = ['就職先を2つ以上入力してください']
       }
     },
-    ...mapActions('analysis', ['setAlternatives'])
+    ...mapActions('analysis', ['setAlternatives', 'setAlternativeEvaluations'])
   }
 }
 </script>

--- a/app/javascript/pages/analysis/CriterionImportance.vue
+++ b/app/javascript/pages/analysis/CriterionImportance.vue
@@ -64,7 +64,7 @@ export default {
       if (this.evaluationData) {
         const raw = [].concat(this.evaluationData)
         const imp = this.$calculator.weightCalculation(this.getCriteria, this.evaluationData)
-        this.setCriterionImportances({imp:imp, raw:raw})
+        this.setCriterionImportances({imp: imp, raw: raw})
         this.$router.push('/analysis/step4')
       } else {
         this.errors = ['未入力の項目があります']

--- a/app/javascript/pages/analysis/CriterionSelect.vue
+++ b/app/javascript/pages/analysis/CriterionSelect.vue
@@ -85,6 +85,10 @@ export default {
       this.selectedCriteria = this.getCriteria
       this.criteria = this.criteria.concat(this.getCriteria.filter(f => !this.criteria.includes(f)))
     }
+    this.$watch('selectedCriteria', function() {
+      this.setCriterionImportances({eval: null, raw: null})
+      this.setAlternativeEvaluations({eval: null, raw: null})
+    })
   },
   methods: {
     addCriterion() {
@@ -102,7 +106,7 @@ export default {
         this.errors = ['条件を2つ以上選んでください']
       }
     },
-    ...mapActions('analysis', ['setCriteria'])
+    ...mapActions('analysis', ['setCriteria', 'setCriterionImportances', 'setAlternativeEvaluations'])
   }
 }
 </script>

--- a/spec/support/analysis_macros.rb
+++ b/spec/support/analysis_macros.rb
@@ -19,7 +19,9 @@ module AnalysisMacros
       i += j
     end
     i.times do |n|
-      find("div[id='0-#{n}']").click
+      within "div[id='0-#{n}']" do
+        find_button('1').click
+      end
       sleep 0.5
     end
     click_on '決定'
@@ -32,7 +34,9 @@ module AnalysisMacros
     end
     criterion_number.times do |m|
       i.times do |n|
-        find("div[id='#{m}-#{n}']").click
+        within "div[id='#{m}-#{n}']" do
+          find_button('1').click
+        end
         sleep 0.5
       end
     end

--- a/spec/system/analysis_spec.rb
+++ b/spec/system/analysis_spec.rb
@@ -6,16 +6,22 @@ RSpec.describe 'Analysis', type: :system do
   describe 'STEP1' do
     before { visit '/analysis/step1' }
     it '入力された就職先が2つ以上のとき次ページに遷移する' do
-      find('#alternative0').set('company0')
-      find('#alternative1').set('company1')
-      click_on '決定'
+      alternative_input(2)
       expect(page).to have_current_path('/analysis/step2'), '次ページに遷移していません'
     end
 
     it '入力された就職先が2つ未満のときエラーメッセージが表示される' do
-      find('#alternative0').set('company0')
-      click_on '決定'
+      alternative_input(1)
       expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
+    end
+
+    it '前のページから戻ったとき以前の入力値が保持されている' do
+      find('#alternative0').set('company0')
+      find('#alternative1').set('company1')
+      click_on '決定'
+      click_on '戻る'
+      expect(page).to have_field('alternative0', with: 'company0'), '以前の入力値が保持されていません'
+      expect(page).to have_field('alternative1', with: 'company1'), '以前の入力値が保持されていません'
     end
   end
 
@@ -25,16 +31,22 @@ RSpec.describe 'Analysis', type: :system do
       alternative_input(alternative_number)
     end
     it '条件が2つ以上選択されているとき次ページに遷移する' do
-      check('criterion0', allow_label_click: true)
-      check('criterion1', allow_label_click: true)
-      click_on '決定'
+      criterion_select(2)
       expect(page).to have_current_path('/analysis/step3'), '次ページに遷移していません'
     end
 
     it '条件が2つ以上選択されていないときエラーメッセージが表示される' do
-      check('criterion0', allow_label_click: true)
-      click_on '決定'
+      criterion_select(1)
       expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
+    end
+
+    it '前のページから戻ったとき以前の入力値が保持されている' do
+      check('criterion0', allow_label_click: true)
+      check('criterion1', allow_label_click: true)
+      click_on '決定'
+      click_on '戻る'
+      expect(page).to have_checked_field('criterion0', visible: false), '以前の入力値が保持されていません'
+      expect(page).to have_checked_field('criterion1', visible: false), '以前の入力値が保持されていません'
     end
   end
 
@@ -53,6 +65,23 @@ RSpec.describe 'Analysis', type: :system do
       criterion_importance(criterion_number-1)
       expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
     end
+
+    it '前のページから戻ったとき以前の入力値が保持されている' do
+      within "div[id='0-0']" do
+        find_button('1').click
+      end
+      within "div[id='0-1']" do
+        find_button('2').click
+      end
+      within "div[id='0-2']" do
+        find_button('3').click
+      end
+      click_on '決定'
+      click_on '戻る'
+      expect(find("div[id='0-0']")).to have_selector('.v-btn--active', text: '1'), '以前の入力値が保持されていません'
+      expect(find("div[id='0-1']")).to have_selector('.v-btn--active', text: '2'), '以前の入力値が保持されていません'
+      expect(find("div[id='0-2']")).to have_selector('.v-btn--active', text: '3'), '以前の入力値が保持されていません'
+    end
   end
 
   describe 'STEP4' do
@@ -70,6 +99,31 @@ RSpec.describe 'Analysis', type: :system do
     it "ラジオボタンがすべて押されていないときエラーメッセージが出る" do
       alternative_evaluation(criterion_number, alternative_number-1)
       expect(page).to have_selector('.error-message'), 'エラーメッセージが表示されていません'
+    end
+
+    it '前のページから戻ったとき以前の入力値が保持されている' do
+      3.times do |n|
+        within "div[id='#{n}-0']" do
+          find_button('1').click
+        end
+        within "div[id='#{n}-1']" do
+          find_button('2').click
+        end
+        within "div[id='#{n}-2']" do
+          find_button('3').click
+        end
+      end
+      click_on '決定'
+      click_on '戻る'
+      expect(find("div[id='0-0']")).to have_selector('.v-btn--active', text: '1'), '以前の入力値が保持されていません'
+      expect(find("div[id='0-1']")).to have_selector('.v-btn--active', text: '2'), '以前の入力値が保持されていません'
+      expect(find("div[id='0-2']")).to have_selector('.v-btn--active', text: '3'), '以前の入力値が保持されていません'
+      expect(find("div[id='1-0']")).to have_selector('.v-btn--active', text: '1'), '以前の入力値が保持されていません'
+      expect(find("div[id='1-1']")).to have_selector('.v-btn--active', text: '2'), '以前の入力値が保持されていません'
+      expect(find("div[id='1-2']")).to have_selector('.v-btn--active', text: '3'), '以前の入力値が保持されていません'
+      expect(find("div[id='2-0']")).to have_selector('.v-btn--active', text: '1'), '以前の入力値が保持されていません'
+      expect(find("div[id='2-1']")).to have_selector('.v-btn--active', text: '2'), '以前の入力値が保持されていません'
+      expect(find("div[id='2-2']")).to have_selector('.v-btn--active', text: '3'), '以前の入力値が保持されていません'
     end
   end
 


### PR DESCRIPTION
# Issue
#26 
# 背景
STEP3やSTEP4で評点を行った後STEP1やSTEP2で選択肢と評価基準を変更すると、取得する評点がずれていた
# 概要
選択肢と評価基準に変更があった場合以前の評点を取得しないよう変更
# 変更点
AlternativeInput.vue（STEP1）
- createdフックでstate.alternativesを取得した後にdata.alternativesに変更があった場合、STEP4で取得する選択肢相対評価データを消去

CriterionSelect.vue（STEP2）
- createdフックでstate.criteriaを取得した後にdata.selectedCriteriaに変更があった場合、STEP3で取得する評価基準重要度データとSTEP4で取得する選択肢相対評価データを消去

spec/system/analysis_spec.rb
- 入力値取得に関するテストを追加